### PR TITLE
expose "Open Folder in New Window" command from editor context and title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this extension will be documented in this file.
 
+## 0.7.0
+
+### Added
+
+- Exposed "Open Folder in New Window" command from editor context and title menus.
+
 ## 0.6.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/shouples/vscode-folder-in-new-window/issues"
   },
   "license": "MIT",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "engines": {
     "vscode": "^1.91.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,20 @@
           "command": "folder-in-new-window.open",
           "group": "navigation@999"
         }
+      ],
+      "editor/context": [
+        {
+          "when": "resourceScheme == file",
+          "command": "folder-in-new-window.open",
+          "group": "navigation@999"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "when": "resourceScheme == file",
+          "command": "folder-in-new-window.open",
+          "group": "navigation@999"
+        }
       ]
     }
   },


### PR DESCRIPTION
Mainly to allow opening a new VS Code window easily when a single file is added to a workspace/window and it isn't shown in the Explorer view.

<img width="1148" height="496" alt="image" src="https://github.com/user-attachments/assets/a78dcee7-a396-4925-ad20-0ef4b41d4dc5" />
