### PR TITLE
update context menu `when` clauses to check for a file system resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,14 +56,14 @@
       ],
       "editor/context": [
         {
-          "when": "resourceScheme == file",
+          "when": "resourceExtname != ''",
           "command": "folder-in-new-window.open",
           "group": "navigation@999"
         }
       ],
       "editor/title/context": [
         {
-          "when": "resourceScheme == file",
+          "when": "resourceExtname != ''",
           "command": "folder-in-new-window.open",
           "group": "navigation@999"
         }

--- a/package.json
+++ b/package.json
@@ -56,14 +56,14 @@
       ],
       "editor/context": [
         {
-          "when": "resourceExtname != ''",
+          "when": "resourceScheme == file || resourceExtname != ''",
           "command": "folder-in-new-window.open",
           "group": "navigation@999"
         }
       ],
       "editor/title/context": [
         {
-          "when": "resourceExtname != ''",
+          "when": "resourceScheme == file || resourceExtname != ''",
           "command": "folder-in-new-window.open",
           "group": "navigation@999"
         }

--- a/package.json
+++ b/package.json
@@ -56,14 +56,14 @@
       ],
       "editor/context": [
         {
-          "when": "resourceScheme == file || resourceExtname != ''",
+          "when": "isFileSystemResource",
           "command": "folder-in-new-window.open",
           "group": "navigation@999"
         }
       ],
       "editor/title/context": [
         {
-          "when": "resourceScheme == file || resourceExtname != ''",
+          "when": "isFileSystemResource",
           "command": "folder-in-new-window.open",
           "group": "navigation@999"
         }


### PR DESCRIPTION
Some files don't use the `file` scheme, but we should still be able to open their parent folder in a new window. For example, Copilot toolset files use the `vscode-userdata` URI scheme instead of `file`:
<img width="1565" height="253" alt="image" src="https://github.com/user-attachments/assets/a9a80585-2722-4943-9c91-d965ca67c1cf" />

These will return `true` for `isFileSystemResource`, along with resources with a `file` URI scheme (whereas resources with the `untitled` URI scheme will return `false`).

see: https://code.visualstudio.com/api/references/when-clause-contexts#available-context-keys
